### PR TITLE
For #186, #188, and #189

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cors": "^2.8.4",
     "coveralls": "^3.0.1",
     "express": "^4.16.2",
-    "express-jwt": "^5.3.0",
+    "express-jwt": "^5.3.1",
     "express-winston": "^2.5.1",
     "istanbul": "^0.4.5",
     "mkdirp": "^0.5.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -91,7 +91,7 @@
     "ify-loader": "^1.1.0",
     "inject-loader": "^3.0.0",
     "karma": "^2.0.3",
-    "karma-coverage": "^1.1.1",
+    "karma-coverage": "^1.1.2",
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-phantomjs-shim": "^1.4.0",

--- a/ui/src/appedit.vue
+++ b/ui/src/appedit.vue
@@ -105,10 +105,17 @@
             <div><!--to keep input indx separate from output-->
                 <div v-for="(input, idx) in app.inputs" :key="idx" style="margin-bottom: 10px;">
                     <b-card style="position: relative;">
+                        <b-row v-if="is_raw(input)">
+                            <b-col>
+                                <b-alert show variant="warning">
+                                    Warning: You have chosen a raw datatype as an input. If possible, please request your upstream app developer to create a new datatype so that it can instead be used to pass data between apps.
+                                </b-alert>
+                            </b-col>
+                        </b-row>
                         <b-row>
                             <b-col cols="5">
                                 <b-input-group prepend="ID">
-                                    <b-form-input type="text" v-model="input.id"required/>
+                                    <b-form-input type="text" v-model="input.id" required />
                                 </b-input-group>
                             </b-col>
                             <b-col cols="7">
@@ -513,7 +520,7 @@ export default {
 
                 });
             });
-        }, res=>{
+        }, res => {
             console.error(res);
         });
     },
@@ -704,6 +711,14 @@ export default {
         editorInit: function() {
             require('brace/mode/json')
             //require('brace/theme/twilight')
+        },
+        is_raw: function(input) {
+            if (this.datatypes) {
+                let dtype = this.datatypes[input.datatype];
+                if (dtype) {
+                    return dtype.name == "raw";
+                }
+            }
         },
     }
 }

--- a/ui/src/apps.vue
+++ b/ui/src/apps.vue
@@ -24,7 +24,7 @@
         <div v-for="tag in sorted_tags" :id="tag">
             <h4 class="group-title">{{tag}}</h4> 
             <div v-for="app in app_groups[tag]" :key="app._id" class="app">
-                <app :app="app" descheight="130px" devsheight="75px"></app>
+                <app :app="app" height="250px"></app>
             </div>
             <br clear="both">
         </div>

--- a/ui/src/components/app.vue
+++ b/ui/src/components/app.vue
@@ -2,7 +2,7 @@
 <div v-if="app_" no-body class="appcard" :class="{'compact': compact, 'clickable': clickable}">
     <div @click="click">
         <div v-if="compact">
-            <appavatar :app="app_" style="float: left;margin-right: 15px;" :width="80" :height="80"/>
+            <appavatar :app="app_" style="float: left; margin-right: 10px;" :width="80" :height="80"/>
             <div style="max-height: 73px; overflow: hidden;">
                 <h4 class="name">
                     <icon v-if="app_.projects && app_.projects.length > 0" scale="0.9" name="lock" title="not working.." class="text-danger"/>
@@ -13,15 +13,15 @@
             </div>
             <slot/>
         </div>
-        <div v-else>
-            <appavatar :app="app_" style="float: left;margin-right: 15px;" :width="80" :height="80"/>
+        <div v-else style="overflow: hidden; position: relative;" :style="{ height }">
+            <appavatar :app="app_" style="float: right; margin-left: 10px;" :width="80" :height="80"/>
             <div class="header">
                 <h4 class="name">
                     <icon v-if="app_.projects && app_.projects.length > 0" name="lock" title="not working.." class="text-danger"/>
                     {{app_.name}}
                 </h4>
                 <h5 class="github">{{app_.github}} <b-badge>{{branch||app_.github_branch}}</b-badge></h5>
-                <div class="datatypes" v-if="!compact">
+                <div class="datatypes">
                     <div class="datatype" v-for="input in app_.inputs" :key="'input.'+input.id">
                         <datatypetag :datatype="input.datatype" :tags="input.datatype_tags"/>
                     </div>
@@ -31,7 +31,7 @@
                     </div>
                 </div>
             </div>
-            <div class="desc" :style="{height: descheight}">{{app_.desc_override||app_.desc||'no description..'}}</div>
+            <div class="desc">{{app_.desc_override||app_.desc||'no description..'}}</div>
             <slot/>
             <div class="stats" v-if="app_.stats && app_.stats.service">
                 <span class="stat" v-b-tooltip.hover title="number of time this App was requested">
@@ -75,8 +75,7 @@ export default {
         appid: String,
         branch: String, //branch to show instead of current app github_branch
         clickable: {type: Boolean, default: true},
-        descheight: String,
-        devsheight: String,
+        height: String,
     },
     data() {
         return {
@@ -130,8 +129,9 @@ background-color: inherit;
 }
 .header {
 margin-right: 10px;
-height: 90px;
-overflow: hidden;
+margin-left: 10px;
+/* min-height: 90px; */
+/* overflow: hidden; */
 }
 .name {
 color: #666;
@@ -148,11 +148,12 @@ margin-bottom: 2px;
 }
 .desc {
 opacity: 0.8;
-overflow: hidden;
 margin-top: 0px;
+padding: 10px;
+margin-bottom: 32px;
 transition: color 0.5s;
 font-size: 90%;
-border: solid 7px white;
+/* border: solid 7px white; */
 }
 
 .image {
@@ -203,6 +204,9 @@ margin-right: 2px;
 margin-top: 2px;
 }
 .stats {
+position:absolute;
+bottom:0;
+width:100%;
 padding: 5px 10px;
 color: #bbb;
 height: 32px;

--- a/ui/src/components/configform.vue
+++ b/ui/src/components/configform.vue
@@ -72,4 +72,3 @@ export default {
     }
 }
 </script>
-

--- a/ui/src/components/product.vue
+++ b/ui/src/components/product.vue
@@ -11,7 +11,7 @@
             <pre v-if="Object.keys(other_product).length != 0" v-highlightjs="JSON.stringify(other_product, null, 4)" style="max-height: 150px;"><code class="json hljs"></code></pre>
         </div>
     </div>
-    <b-tabs class="brainlife-tab" v-model="plotidx" v-if="ready">
+    <b-tabs class="brainlife-tab" v-model="plotidx">
         <b-tab v-for="(p, $idx) in plots" :title="p.name||$idx" :key="$idx">
             <vue-plotly :data="p.data" :layout="p.layout" :options="p.options" ref="plotrefs" :autoResize="true"/>
         </b-tab>
@@ -33,19 +33,13 @@ export default {
         return {
             config: Vue.config,
             plotidx: null,
-            ready: false,
         }
-    },
-    mounted() {
-        setTimeout(() => {
-            this.ready = true;
-        }, 1000);
     },
     
     computed: {
         other_product: function() {
             let all = Object.assign({}, this.product);
-            delete all.brainlife; 
+            delete all.brainlife;
             return all;
         },
         alerts: function() {

--- a/ui/src/components/product.vue
+++ b/ui/src/components/product.vue
@@ -11,7 +11,7 @@
             <pre v-if="Object.keys(other_product).length != 0" v-highlightjs="JSON.stringify(other_product, null, 4)" style="max-height: 150px;"><code class="json hljs"></code></pre>
         </div>
     </div>
-    <b-tabs class="brainlife-tab" v-model="plotidx">
+    <b-tabs class="brainlife-tab" v-model="plotidx" v-if="ready">
         <b-tab v-for="(p, $idx) in plots" :title="p.name||$idx" :key="$idx">
             <vue-plotly :data="p.data" :layout="p.layout" :options="p.options" ref="plotrefs" :autoResize="true"/>
         </b-tab>
@@ -33,8 +33,15 @@ export default {
         return {
             config: Vue.config,
             plotidx: null,
+            ready: false,
         }
     },
+    mounted() {
+        setTimeout(() => {
+            this.ready = true;
+        }, 1000);
+    },
+    
     computed: {
         other_product: function() {
             let all = Object.assign({}, this.product);

--- a/ui/src/modals/dataset.vue
+++ b/ui/src/modals/dataset.vue
@@ -370,10 +370,7 @@ export default {
 
         close: function() {
             if(!this.dataset) return;
-            if(this.back) {
-                // this.$router.push(this.back); // causes problems sometimes
-                this.$router.push(this.$route.path.replace(this.dataset._id, ""));
-            }
+            this.$router.push(this.$route.path.replace(this.dataset._id, ""));
             this.dataset = null;
         },
 

--- a/ui/src/modals/dataset.vue
+++ b/ui/src/modals/dataset.vue
@@ -275,6 +275,13 @@ export default {
                 this.load_apps();
             }
         },
+        '$route': function() {
+            if (this.dataset) {
+                if (this.$route.params.tab != 'dataset') {
+                    this.close();
+                }
+            }
+        },
     },
 
     methods: {
@@ -363,7 +370,10 @@ export default {
 
         close: function() {
             if(!this.dataset) return;
-            if(this.back) this.$router.push(this.back);
+            if(this.back) {
+                // this.$router.push(this.back); // causes problems sometimes
+                this.$router.push(this.$route.path.replace(this.dataset._id, ""));
+            }
             this.dataset = null;
         },
 

--- a/ui/src/modals/dataset.vue
+++ b/ui/src/modals/dataset.vue
@@ -172,7 +172,7 @@
                     <b-alert show variant="info" v-if="apps.length == 0">There are currently no applications that use the datatype from this dataset.</b-alert>
                     <div v-for="app in apps" :key="app._id" style="width: 33%; float: left;">
                         <div style="margin-right: 10px; margin-bottom: 10px;" @click="openapp(app._id)">
-                            <app :app="app" descheight="150px" :clickable="false"></app>
+                            <app :app="app" height="270px" :clickable="false"></app>
                         </div>
                     </div>
                 </div>

--- a/ui/src/modals/datasetselecter.vue
+++ b/ui/src/modals/datasetselecter.vue
@@ -254,7 +254,7 @@ export default {
             }}).then(res=>{
                 this.subjects = res.body;
             });
-         }
+        },
     },
 
     created: function() {

--- a/ui/src/modals/datatype.vue
+++ b/ui/src/modals/datatype.vue
@@ -65,6 +65,14 @@ export default {
             }
         });
     },
+    
+    watch: {
+        '$route': function() {
+            if (!this.$route.path.startsWith('/datatypes')) {
+                this.close();
+            }
+        },
+    },
 
     methods: {
         load: function(id) {
@@ -94,7 +102,7 @@ export default {
     
         close: function() {
             if(!this.datatype) return;
-            this.$router.replace("/datatypes");
+            this.$router.push(this.$route.path.replace(this.datatype._id, ""));
             this.datatype = null;
         },
         

--- a/ui/src/modals/datatype.vue
+++ b/ui/src/modals/datatype.vue
@@ -21,7 +21,7 @@
                     <p v-else>The following apps require this datatype as an input.</p>
                     <div v-for="app in apps" :key="app._id" style="display:inline-block; width: 33%;">
                         <div style="margin-left: 5px; margin-right: 5px; margin-bottom: 10px; cursor: pointer;" @click="openapp(app._id)">
-                            <app :app="app" descheight="80px" :clickable="false"></app>
+                            <app :app="app" height="200px" :clickable="false"></app>
                         </div>
                     </div>
                 </div>

--- a/ui/src/modals/newtask.vue
+++ b/ui/src/modals/newtask.vue
@@ -20,7 +20,7 @@
 
         <div style="width: 50%; float: left;" v-for="app in apps" :key="app._id">
             <div @click="selectapp(app)" style="padding-bottom: 5px; padding-right: 10px;">
-                <app :app="app" :compact="true" :clickable="false" class="clickable" descheight="50px"/>
+                <app :app="app" :compact="true" :clickable="false" class="clickable" height="170px"/>
             </div>
         </div>
         <br clear="both">
@@ -28,7 +28,7 @@
 
     <!--app configuration page--> 
     <b-form v-if="app" class="submit-form" @submit="submit">
-        <app :app="app" :compact="false"/>
+        <app :app="app" :compact="false" />
         <br>
 
         <!--input-->

--- a/ui/src/pub.vue
+++ b/ui/src/pub.vue
@@ -257,7 +257,7 @@
                         <p class="text-muted">Following applications are used to generate published datasets.</p>
                         <b-row>
                             <b-col cols="6" v-for="app in apps" :key="app._id" style="margin-bottom: 10px;">
-                                <app :app="app" descheight="130px" :compact="true"></app>
+                                <app :app="app" height="250px" :compact="true"></app>
                             </b-col>
                         </b-row>
                     </div>


### PR DESCRIPTION
* Modals no longer return 404 when the close button is hit on another page (#186)
* The dataset and datatype modals are automatically hidden if a new page is visited
* Header expanded into description for #188, and the app card layout is now a little different (icon on the right, description set to expand below the icon where there is whitespace)
* descheight prop completely replaced with height, which determines the height of the whole card
* Added warning when raw datatype is used as an input for an app (#189), and it states the following: "Warning: You have chosen a raw datatype as an input. If possible, please request your upstream app developer to create a new datatype so that it can instead be used to pass data between apps."